### PR TITLE
Say hello

### DIFF
--- a/src/hooks/useUser.js
+++ b/src/hooks/useUser.js
@@ -110,6 +110,8 @@ export const useUser = () => {
       
       const token = sessionStorage.getItem('authToken');
       if (token) {
+        // Ensure apiService has the token so that authenticated requests include Authorization header
+        apiService.setToken(token);
         try {
           const response = await apiService.getProfile();
           if (response.success) {


### PR DESCRIPTION
Set JWT token in `ApiService` on `useUser` initialization.

The login functionality was failing after a page reload because the `ApiService` was not re-setting the JWT token from session storage, leading to subsequent API calls failing due to missing `Authorization` headers. This change ensures the token is immediately set in `ApiService` when `useUser` initializes, maintaining the user's logged-in state across page refreshes.

---
<a href="https://cursor.com/background-agent?bcId=bc-afc392f0-63e3-4fce-8b7e-fe3fabf74c68">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-afc392f0-63e3-4fce-8b7e-fe3fabf74c68">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

